### PR TITLE
EmptyStrToNone supports `AnyHttpUrl`

### DIFF
--- a/src/rtmilk/utils.py
+++ b/src/rtmilk/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from typing import Generic, Optional, TypeVar
 
 from pydantic.fields import ModelField # pylint: disable=no-name-in-module
+from pydantic.networks import AnyHttpUrl # pylint: disable=no-name-in-module
 
 PydanticField = TypeVar('PydanticField')
 
@@ -15,4 +16,9 @@ class EmptyStrToNone(Generic[PydanticField]):
 	def validate(cls, v: PydanticField, field: ModelField) -> Optional[PydanticField]: # pylint: disable=unused-argument
 		if v == '':
 			return None
-		return datetime.strptime(v, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+		type_ = field.sub_fields[0].type_
+		if isinstance(type_, datetime):
+			return datetime.strptime(v, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+		if isinstance(type_, AnyHttpUrl):
+			return AnyHttpUrl(v)
+		return v


### PR DESCRIPTION
If the task has `url`, an error occurs.

```python
from rtmilk import TasksGetList
from fake import fake

fake = {'stat': 'ok',
        'tasks': {
            'list': [
                {'id': '123456',
                 'taskseries': [
                     {'created': '2022-09-28T01:52:58Z',
                      'id': '123456',
                      'location_id': '',
                      'modified': '2022-09-28T01:52:58Z',
                      'name': 'Test',
                      'notes': [],
                      'parent_task_id': '',
                      'participants': [],
                      'rrule': {'$t': 'FREQ=MONTHLY;INTERVAL=1;WKST=SU',
                                'every': '0'},
                      'source': 'js',
                      'tags': [],
                      'task': [
                          {'added': '2022-09-28T01:52:58Z',
                           'completed': '',
                           'deleted': '',
                           'due': '2022-10-27T15:00:00Z',
                           'estimate': '',
                           'has_due_time': '0',
                           'has_start_time': '0',
                           'id': '123456',
                           'postponed': '0',
                           'priority': 'N',
                           'start': ''}
                          ],
                      'url': 'https://example.com'},
                     ]}],
           'rev': '87847jglkfujagg7gei543897jgslkg'}}

r = TasksGetList.Out(**fake)
print(r)
```

raises

```
Traceback (most recent call last):
  File "/home/anekos/sandbox/python/rtmilk-test/.venv/lib/python3.10/site-packages/rtmilk/sansio.py", line 34, in _ValidateReturn
    return type_(**rsp)
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for TaskListResponse
tasks -> list -> 0 -> taskseries -> 0 -> url
  time data 'https://example.com' does not match format '%Y-%m-%dT%H:%M:%SZ' (type=value_error)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/anekos/sandbox/python/rtmilk-test/t.py", line 41, in <module>
    r = TasksGetList.Out(**fake)
  File "/home/anekos/sandbox/python/rtmilk-test/.venv/lib/python3.10/site-packages/rtmilk/sansio.py", line 267, in Out
    return _ValidateReturn(TaskListResponse, rsp)
  File "/home/anekos/sandbox/python/rtmilk-test/.venv/lib/python3.10/site-packages/rtmilk/sansio.py", line 37, in _ValidateReturn
    failStat = FailStat(**rsp)
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 2 validation errors for FailStat
stat
  string does not match regex "fail" (type=value_error.str.regex; pattern=fail)
err
  field required (type=value_error.missing)
```
